### PR TITLE
refactor: apply errorHandler

### DIFF
--- a/src/controller/member/controller.ts
+++ b/src/controller/member/controller.ts
@@ -1,13 +1,14 @@
 import { RequestHandler } from 'express';
 import MemberService from '../../service/member.service';
 import { MemberSearchResDTO } from '../../type/member.dto';
+import { BadRequestError } from '../../util/customErrors';
 
-export const searchMember: RequestHandler = async (req, res) => {
+export const searchMember: RequestHandler = async (req, res, next) => {
   try {
     const { email } = req.query;
     const member = await MemberService.getMemberByEmail(email as string);
     if (!member) {
-      return res.status(400).json({ message: '결과가 없습니다.' });
+      throw new BadRequestError('결과가 없습니다.');
     }
 
     const memberData: MemberSearchResDTO = {
@@ -16,6 +17,6 @@ export const searchMember: RequestHandler = async (req, res) => {
     };
     res.status(200).json(memberData);
   } catch (error) {
-    res.status(400);
+    next(error);
   }
 };


### PR DESCRIPTION
## 추가한 점
- 전체 코드의 errorhandler 수정

1. 회원가입 (/register)

회원가입 성공
<img width="869" alt="register" src="https://github.com/KWEBofficial/anytime-server/assets/96991702/7de4c067-01ec-488d-bc50-f38aacf74363">

이메일 중복으로 인한 회원가입 실패
<img width="869" alt="기존 email register" src="https://github.com/KWEBofficial/anytime-server/assets/96991702/1f119a12-9c84-489b-ac88-cb18871defb0">

2. 로그인(/login)

로그인 성공
<img width="869" alt="login" src="https://github.com/KWEBofficial/anytime-server/assets/96991702/7c967625-7a8a-4afe-8c3a-d01db7105c62">

로그인 실패(아이디 없음)
<img width="869" alt="login id error" src="https://github.com/KWEBofficial/anytime-server/assets/96991702/de5674c1-2572-4a8e-a476-f67e0c4d88d2">

로그인 실패(비밀번호 틀림)
<img width="869" alt="login pw error" src="https://github.com/KWEBofficial/anytime-server/assets/96991702/a23209fb-4f22-46df-8dfe-92d81f43a16e">

3. 로그아웃(/logout)
로그아웃 성공
<img width="869" alt="logout" src="https://github.com/KWEBofficial/anytime-server/assets/96991702/88abe0c0-815e-49b5-9cf4-b432b617a48d">

로그아웃 실패(로그인 되어 있지 않음)
<img width="869" alt="logout 401" src="https://github.com/KWEBofficial/anytime-server/assets/96991702/506098db-7265-4558-8c05-a22e6330b32b">

4. 멤버검색(/member/search?email={})
검색 성공
<img width="869" alt="search" src="https://github.com/KWEBofficial/anytime-server/assets/96991702/4810654d-09b2-4105-9dc9-17d04b9f2853">

검색 실패(로그인 되어 있지 않음)
<img width="869" alt="search 401" src="https://github.com/KWEBofficial/anytime-server/assets/96991702/219bbb51-f94d-4d36-97ee-531ec415862a">

검색한 이메일을 가진 유저 존재하지 않음 
<img width="869" alt="search 400" src="https://github.com/KWEBofficial/anytime-server/assets/96991702/26c10567-4925-4804-8460-58b3c8a1040d">

