### PR TITLE
feat: 팀 정보 조회, 권한 확인 구현

### DIFF
--- a/src/controller/team/controller.ts
+++ b/src/controller/team/controller.ts
@@ -2,8 +2,12 @@ import { RequestHandler } from 'express';
 import TeamService from '../../service/team.service';
 import {
   MyTeamResDTO,
+  NoticesDTO,
+  SchedulesDTO,
   TeamCreateReqDTO,
   TeamListResDTO,
+  TeamMemberDTO,
+  TeamReadResDTO,
   TeamUpdateReqDTO,
 } from '../../type/team.dto';
 import Team from '../../entity/team.entity';
@@ -12,6 +16,10 @@ import {
   ForbiddenError,
   UnauthorizedError,
 } from '../../util/customErrors';
+import MemberTeamService from '../../service/memberTeam.service';
+import ScheService from '../../service/schedule.service';
+import NoticeService from '../../service/notice.service';
+import { NoticeResDTO } from '../../type/notice.dto';
 
 declare module 'express-session' {
   interface SessionData {
@@ -71,14 +79,23 @@ export const searchTeam: RequestHandler = async (req, res, next) => {
 // param와 body를 사용하여 해당하는 team 정보 수정
 export const updateTeam: RequestHandler = async (req, res, next) => {
   try {
-    const id = Number(req.params.teamId);
-    if (isNaN(id)) throw new BadRequestError('teamId가 숫자가 아닙니다.');
+    const memberId = req.session.passport?.user;
+    if (!memberId) throw new UnauthorizedError('로그인이 필요합니다.');
+
+    const teamId = Number(req.params.teamId);
+    if (isNaN(teamId)) throw new BadRequestError('teamId가 숫자가 아닙니다.');
+
+    const memberTeam = await NoticeService.findMemberTeam(memberId, teamId);
+    if (!memberTeam)
+      throw new BadRequestError('해당하는 모임에 소속되어 있지 않습니다.');
+    if (!memberTeam.isAdmin) throw new ForbiddenError('권한이 없습니다.');
+
     const { teamname, color, explanation } = req.body as TeamUpdateReqDTO;
     const createTeamInput = { teamname, color, explanation };
 
-    const team = await TeamService.updateTeam(id, createTeamInput);
+    const team = await TeamService.updateTeam(teamId, createTeamInput);
 
-    if (!team) throw new BadRequestError('존재하지 않는 팀입니다.');
+    if (!team) throw new BadRequestError('해당하는 모임이 없습니다.');
     else res.status(200).json(team.id);
   } catch (error) {
     next(error);
@@ -87,16 +104,64 @@ export const updateTeam: RequestHandler = async (req, res, next) => {
 
 export const showTeam: RequestHandler = async (req, res, next) => {
   try {
-    const id = Number(req.params.teamId);
-    const teamInfo = await TeamService.getTeamById(id);
+    const teamId = Number(req.params.teamId);
+    if (isNaN(teamId)) throw new BadRequestError('teamId가 숫자가 아닙니다.');
+    const memberId = req.session.passport?.user;
+    if (!memberId) throw new UnauthorizedError('로그인이 필요합니다.');
+
+    const memberTeam = await NoticeService.findMemberTeam(memberId, teamId);
+    if (!memberTeam)
+      throw new BadRequestError('해당하는 모임에 소속되어 있지 않습니다.');
+
+    const teamInfo = await TeamService.getTeamById(teamId);
     if (teamInfo) {
       const { teamname, color, explanation, isPublic } = teamInfo;
-    } else throw new BadRequestError('존재하지 않는 팀입니다.');
 
-    // team id로 schedule 찾기 - ScheduleService
-    // team id로 notice 찾기 - NoticeService
-    // team id로 member 찾기 - memberTeam table
-    // user id로 해당 team의 admin인지 확인
+      // team id로 schedule 찾기
+      const scheduleList = await ScheService.ScheFindByTeam(teamInfo);
+      if (!scheduleList) throw new BadRequestError('해당하는 모임이 없습니다.');
+      const schedules = scheduleList.map((schedule) => {
+        return <SchedulesDTO>{
+          id: schedule.id,
+          schedulename: schedule.schedulename,
+          startTime: schedule.startTime,
+          endTime: schedule.endTime,
+          explanation: schedule.explanation,
+        };
+      });
+
+      // team id로 notice 찾기
+      const noticeList = await NoticeService.getNoticeByTeamId(teamId);
+      if (!noticeList) throw new BadRequestError('해당하는 모임이 없습니다.');
+      const notices = noticeList.map((notice) => {
+        return <NoticesDTO>{
+          id: notice.id,
+          content: notice.content,
+          createdAt: notice.createdAt,
+          isPrior: notice.isPrior,
+        };
+      });
+      // team id로 member 찾기
+      const members = (await TeamService.getMemberByTeam(
+        teamId,
+      )) as TeamMemberDTO[];
+
+      // user id로 해당 team의 admin인지 확인
+      const isAdmin = await TeamService.getIsAdmin(memberId, teamId);
+
+      const TeamReadRes: TeamReadResDTO = {
+        teamname,
+        color,
+        explanation,
+        isPublic,
+        schedules,
+        notices,
+        members,
+        isAdmin,
+      };
+
+      res.status(200).json(TeamReadRes);
+    } else throw new BadRequestError('해당하는 모임이 없습니다.');
   } catch (error) {
     next(error);
   }
@@ -104,12 +169,20 @@ export const showTeam: RequestHandler = async (req, res, next) => {
 
 export const deleteTeam: RequestHandler = async (req, res, next) => {
   try {
-    const id = Number(req.params.teamId);
-    if (isNaN(id)) throw new BadRequestError('teamId가 숫자가 아닙니다.');
-    const result = await TeamService.deleteTeam(id);
+    const memberId = req.session.passport?.user;
+    if (!memberId) throw new UnauthorizedError('로그인이 필요합니다.');
+    const teamId = Number(req.params.teamId);
+    if (isNaN(teamId)) throw new BadRequestError('teamId가 숫자가 아닙니다.');
+
+    const memberTeam = await NoticeService.findMemberTeam(memberId, teamId);
+    if (!memberTeam)
+      throw new BadRequestError('해당하는 모임에 소속되어 있지 않습니다.');
+    if (!memberTeam.isAdmin) throw new ForbiddenError('권한이 없습니다.');
+
+    const result = await TeamService.deleteTeam(teamId);
 
     if (result) res.status(200).json({ message: 'delete' });
-    else throw new BadRequestError('존재하지 않는 팀입니다.');
+    else throw new BadRequestError('해당하는 모임이 없습니다.');
   } catch (error) {
     next(error);
   }

--- a/src/controller/team/router.ts
+++ b/src/controller/team/router.ts
@@ -4,7 +4,7 @@ import {
   myTeam,
   searchTeam,
   updateTeam,
-  //showTeam,
+  showTeam,
   deleteTeam,
 } from './controller';
 import { isLoggedIn } from '../auth/controller';
@@ -15,7 +15,7 @@ teamRouter.post('/create', isLoggedIn, createTeam); // body를 사용하여 team
 teamRouter.get('/', isLoggedIn, myTeam); // userId에 맞는 team 정보 가져오기
 teamRouter.get('/search', isLoggedIn, searchTeam); // query를 사용하여 team 정보 가져오기
 teamRouter.patch('/:teamId', isLoggedIn, updateTeam); // param와 body를 사용하여 해당하는 team 정보 수정
-//teamRouter.get('/team/:teamId', isLoggedIn, showTeam); // param을 사용하여 해당하는 team 정보 가져오기
+teamRouter.get('/:teamId', isLoggedIn, showTeam); // param을 사용하여 해당하는 team 정보 가져오기
 teamRouter.delete('/:teamId', isLoggedIn, deleteTeam); // param을 사용하여 해당하는 team 정보 삭제
 
 export default teamRouter;

--- a/src/service/team.service.ts
+++ b/src/service/team.service.ts
@@ -78,7 +78,40 @@ export default class TeamService {
         ])
         .where('m.member_id = :id', { id: id })
         .getRawMany();
-    } catch (error) {}
+    } catch (error) {
+      throw new InternalServerError('멤버-팀 정보를 불러오는데 실패했습니다.');
+    }
+  }
+
+  static async getMemberByTeam(id: number) {
+    try {
+      return await MemberTeamRepository.createQueryBuilder('mt')
+        .leftJoin(Member, 'm', 'm.id = mt.member_id')
+        .select([
+          'm.id AS id',
+          'm.membername AS name',
+          'mt.is_admin AS isAdmin',
+        ])
+        .where('mt.team_id = :id', { id: id })
+        .getRawMany();
+    } catch (error) {
+      throw new InternalServerError('팀-멤버 정보를 불러오는데 실패했습니다.');
+    }
+  }
+
+  static async getIsAdmin(
+    memberId: number,
+    teamId: number,
+  ): Promise<boolean | null> {
+    try {
+      const memberTeam = await MemberTeamRepository.findOne({
+        where: { member: { id: memberId }, team: { id: teamId } },
+      });
+      if (memberTeam) return memberTeam.isAdmin;
+      else return null;
+    } catch (error) {
+      throw new InternalServerError('어드민 여부를 불러오는데 실패했습니다.');
+    }
   }
 
   static async updateTeam(

--- a/src/type/team.dto.ts
+++ b/src/type/team.dto.ts
@@ -36,13 +36,28 @@ export interface TeamMemberDTO {
   isAdmin: boolean;
 }
 
+export interface SchedulesDTO {
+  id: number;
+  schedulename: string;
+  startTime: Date;
+  endTime: Date;
+  explanation: string;
+}
+
+export interface NoticesDTO {
+  id: number;
+  content: string;
+  createdAt: Date;
+  isPrior: boolean;
+}
+
 export interface TeamReadResDTO {
   teamname: string;
   color: number;
   explanation: string;
   isPublic: boolean;
   members: TeamMemberDTO[];
-  schedules: ScheduleDTO[];
-  notices: NoticeResDTO[];
-  isAdmin: boolean;
+  schedules: SchedulesDTO[];
+  notices: NoticesDTO[];
+  isAdmin: boolean | null;
 }


### PR DESCRIPTION
## 추가한 점
- GET team/:teamId
- isAdmin controller
- error handling

### 1. 팀 정보 조회
**GET team/:teamId**
: 모임 메인 페이지에 띄울 정보들(팀 정보/팀에 속한 멤버 정보/팀 일정 정보/관리자 여부) 조회
![image](https://github.com/KWEBofficial/anytime-server/assets/129853673/d3c3a64a-1e7e-44f3-b265-3b68ef92678e)
![image](https://github.com/KWEBofficial/anytime-server/assets/129853673/8a1eff4c-f0d5-4207-aec1-4da33d07ba4a)

![image](https://github.com/KWEBofficial/anytime-server/assets/129853673/5b81bcf0-2e2d-4ca9-9b31-7b87176d2c64)

### 2. isAdmin controller 추가 & error handling 
: 팀 정보를 삭제하거나 수정할 때 해당 팀의 어드민인지 확인
![image](https://github.com/KWEBofficial/anytime-server/assets/129853673/61d753e1-3baf-4d65-b5f6-99b2f57947ff)

: 팀 정보를 조회할 때 해당 팀의 멤버인지 확인
![image](https://github.com/KWEBofficial/anytime-server/assets/129853673/a4637b1b-504b-4c16-9e82-3e8f59976bd9)
