### PR TITLE
fix: isAdmin controller teamId 

### DIFF
--- a/src/controller/notice/controller.ts
+++ b/src/controller/notice/controller.ts
@@ -109,7 +109,8 @@ export const isAdmin: RequestHandler = async (req, res, next) => {
       );
       if (!memberTeam)
         throw new BadRequestError('해당하는 모임에 소속되어 있지 않습니다.');
-      if (!memberTeam.isAdmin) throw new ForbiddenError('권한이 없습니다.');
+      if (team.isPublic && !memberTeam.isAdmin)
+        throw new ForbiddenError('권한이 없습니다.');
     } else if (noticeId) {
       if (isNaN(Number(noticeId)))
         throw new BadRequestError('noticeId가 숫자가 아닙니다.');
@@ -134,18 +135,12 @@ export const isAdmin: RequestHandler = async (req, res, next) => {
       if (teamSchedule) {
         const teamId = teamSchedule.team.id;
         const isPublic = teamSchedule.team.isPublic;
-        if (!isPublic) next();
-        else {
-          const memberTeam = await NoticeService.findMemberTeam(
-            memberId,
-            teamId,
-          );
-          if (!memberTeam)
-            throw new BadRequestError(
-              '해당하는 모임에 소속되어 있지 않습니다.',
-            );
-          if (!memberTeam.isAdmin) throw new ForbiddenError('권한이 없습니다.');
-        }
+
+        const memberTeam = await NoticeService.findMemberTeam(memberId, teamId);
+        if (!memberTeam)
+          throw new BadRequestError('해당하는 모임에 소속되어 있지 않습니다.');
+        if (isPublic && !memberTeam.isAdmin)
+          throw new ForbiddenError('권한이 없습니다.');
       }
     }
     next();

--- a/src/repository/memberTeam.respository.ts
+++ b/src/repository/memberTeam.respository.ts
@@ -1,6 +1,0 @@
-import AppDataSource from '../config/dataSource';
-import MemberTeam from '../entity/memberTeam.entity';
-
-const MemberTeamRepository = AppDataSource.getRepository(MemberTeam).extend({});
-
-export default MemberTeamRepository;

--- a/src/service/notice.service.ts
+++ b/src/service/notice.service.ts
@@ -1,13 +1,11 @@
-import { DeleteResult, createQueryBuilder } from 'typeorm';
+import { DeleteResult } from 'typeorm';
 import Notice from '../entity/notice.entity';
 import NoticeRepository from '../repository/notice.repository';
 import TeamRepository from '../repository/team.repository';
 import { BadRequestError, InternalServerError } from '../util/customErrors';
 import Team from '../entity/team.entity';
-import MemberRepository from '../repository/member.repository';
-import Member from '../entity/member.entity';
 import MemberTeam from '../entity/memberTeam.entity';
-import MemberTeamRepository from '../repository/memberTeam.respository';
+import MemberTeamRepository from '../repository/memberTeam.repository';
 import Schedule from '../entity/schedule.entity';
 import ScheduleRepository from '../repository/schedule.repository';
 import TeamScheduleRepository from '../repository/teamSchedule.repository';


### PR DESCRIPTION
## 추가한 점
- isAdmin controller가 teamId를 받을 시 사적모임일 경우 admin을 따지지 않음
- isAdmin controller가 scheduleId를 받을시 사적모임의 일정일 경우 모임의 인원인지 따짐
- memberTeam.respository.ts 파일 삭제. memberTeam.respository.ts 파일을 사용하도록 함