### PR TITLE
modify: getNotices controller 수정, team router 수정

### DIFF
--- a/src/controller/notice/controller.ts
+++ b/src/controller/notice/controller.ts
@@ -60,6 +60,8 @@ export const getNotices: RequestHandler = async (req, res, next) => {
           new Date() > notice.startDate &&
           new Date() < notice.endDate,
       )
+      .sort((a, b) => Number(b.updatedAt) - Number(a.updatedAt))
+      .sort((a, b) => Number(b.isPrior) - Number(a.isPrior)) // isPrior=0인 것도 보내야 할 수 있음
       .map((notice) => {
         return <NoticeResDTO>{
           noticeId: notice.id,
@@ -67,7 +69,8 @@ export const getNotices: RequestHandler = async (req, res, next) => {
           createdAt: notice.createdAt,
           isPrior: notice.isPrior,
         };
-      });
+      })
+      .slice(0, 2);
     res.status(200).json(noticeList);
   } catch (error) {
     next(error);

--- a/src/controller/team/controller.ts
+++ b/src/controller/team/controller.ts
@@ -133,14 +133,25 @@ export const showTeam: RequestHandler = async (req, res, next) => {
       // team id로 notice 찾기
       const noticeList = await NoticeService.getNoticeByTeamId(teamId);
       if (!noticeList) throw new BadRequestError('해당하는 모임이 없습니다.');
-      const notices = noticeList.map((notice) => {
-        return <NoticesDTO>{
-          id: notice.id,
-          content: notice.content,
-          createdAt: notice.createdAt,
-          isPrior: notice.isPrior,
-        };
-      });
+      const notices = noticeList
+        .filter(
+          (notice) =>
+            notice.startDate &&
+            notice.endDate &&
+            new Date() > notice.startDate &&
+            new Date() < notice.endDate,
+        )
+        .sort((a, b) => Number(b.updatedAt) - Number(a.updatedAt))
+        .sort((a, b) => Number(b.isPrior) - Number(a.isPrior))
+        .map((notice) => {
+          return <NoticesDTO>{
+            id: notice.id,
+            content: notice.content,
+            createdAt: notice.createdAt,
+            isPrior: notice.isPrior,
+          };
+        })
+        .slice(0, 2);
       // team id로 member 찾기
       const members = (await TeamService.getMemberByTeam(
         teamId,

--- a/src/controller/team/router.ts
+++ b/src/controller/team/router.ts
@@ -18,7 +18,6 @@ import {
 
 const teamRouter = Router();
 
-
 teamRouter.patch('/favorite/:teamId', toggleFavoriteTeam);
 teamRouter.patch('/hide/:teamId', toggleHideTeam);
 
@@ -32,7 +31,7 @@ teamRouter.post('/create', createTeam); // body를 사용하여 team 정보 저�
 teamRouter.get('/', myTeam); // userId에 맞는 team 정보 가져오기
 teamRouter.get('/search', searchTeam); // query를 사용하여 team 정보 가져오기
 teamRouter.patch('/:teamId', updateTeam); // param와 body를 사용하여 해당하는 team 정보 수정
-//teamRouter.get('/team/:teamId', showTeam); // param을 사용하여 해당하는 team 정보 가져오기
+teamRouter.get('/:teamId', showTeam); // param을 사용하여 해당하는 team 정보 가져오기
 teamRouter.delete('/:teamId', deleteTeam); // param을 사용하여 해당하는 team 정보 삭제
 
 export default teamRouter;

--- a/src/entity/notice.entity.ts
+++ b/src/entity/notice.entity.ts
@@ -47,7 +47,7 @@ export default class Notice {
   createdAt!: Date;
 
   @UpdateDateColumn({ type: 'timestamp', nullable: true })
-  updatedAt?: Date;
+  updatedAt!: Date;
 
   @DeleteDateColumn({ type: 'timestamp', nullable: true })
   deletedAt?: Date;


### PR DESCRIPTION
## 수정한 점
- getNotices controller, showTeam controller 수정
- notice entity 수정
- team router 수정

#### 1. getNotices controller, showTeam controller
showTeam controller의 notices 구하는 부분에서 1. 중요표시가 된 것 2. 가장 updateAt이 빠른 것을 우선순위로 정렬하여 2개만 보내주도록 수정함. getNotices는 사용하지 않아서 삭제해도 될 것 같음 

#### 2. notice entity
updateAt은 생성될 때 자동으로 생성되어서 `updateAt?: Date`가 아니라 `updateAt!: Date`가 맞음. entity 수정은 다 해서 올리기로 했지만 getNotices 고칠 때 이걸 건드려야 해서 미리 올림
#### 3. team router 
get method에 /team/:teamId 경로일 때 showTeam controller가 사용될 수 있게 수정함.