### PR TITLE
modify: color type -> string

### DIFF
--- a/src/controller/memberTeam/controller.ts
+++ b/src/controller/memberTeam/controller.ts
@@ -4,6 +4,7 @@ import MemberService from '../../service/member.service';
 import { BadRequestError, ForbiddenError } from '../../util/customErrors';
 import { InviteReqDTO, AdminReqDTO } from '../../type/memberTeam.dto';
 import AlarmService from '../../service/alarm.service';
+import TeamService from '../../service/team.service';
 
 declare module 'express-session' {
   interface SessionData {
@@ -69,11 +70,8 @@ export const inviteMember: RequestHandler = async (req, res, next) => {
       throw new BadRequestError('초대하고자 하는 그룹에 속해있지 않습니다');
 
     if (invite === true) throw new BadRequestError('이미 초대된 유저입니다.');
-
-    await AlarmService.createInviteAlarm(
-      inviteReqDTO.memberId,
-      inviteReqDTO.teamId,
-    );
+    const team = await TeamService.getTeamById(inviteReqDTO.teamId);
+    if (team) await AlarmService.createInviteAlarm(inviteReqDTO.memberId, team);
     return res.status(200).json();
   } catch (error) {
     next(error);

--- a/src/controller/memberTeam/controller.ts
+++ b/src/controller/memberTeam/controller.ts
@@ -71,7 +71,12 @@ export const inviteMember: RequestHandler = async (req, res, next) => {
 
     if (invite === true) throw new BadRequestError('이미 초대된 유저입니다.');
     const team = await TeamService.getTeamById(inviteReqDTO.teamId);
-    if (team) await AlarmService.createInviteAlarm(inviteReqDTO.memberId, team);
+    if (team)
+      await AlarmService.createAlarm(
+        `${team.teamname} 그룹에 초대되었습니다.`,
+        inviteReqDTO.memberId,
+        inviteReqDTO.teamId,
+      );
     return res.status(200).json();
   } catch (error) {
     next(error);
@@ -94,7 +99,13 @@ export const toggleAdmin: RequestHandler = async (req, res, next) => {
       throw new BadRequestError(
         '존재하지 않는 유저이거나 그룹 소속이 아닙니다.',
       );
-
+    const team = await TeamService.getTeamById(adminReqDTO.teamId);
+    if (team)
+      await AlarmService.createAlarm(
+        `${team.teamname}의 관리자가 되었습니다.`,
+        adminReqDTO.memberId,
+        adminReqDTO.teamId,
+      );
     return res.status(200).json();
   } catch (error) {
     next(error);

--- a/src/controller/notice/controller.ts
+++ b/src/controller/notice/controller.ts
@@ -60,6 +60,8 @@ export const getNotices: RequestHandler = async (req, res, next) => {
           new Date() > notice.startDate &&
           new Date() < notice.endDate,
       )
+      .sort((a, b) => Number(b.updatedAt) - Number(a.updatedAt))
+      .sort((a, b) => Number(b.isPrior) - Number(a.isPrior)) // isPrior=0인 것도 보내야 할 수 있음
       .map((notice) => {
         return <NoticeResDTO>{
           noticeId: notice.id,
@@ -67,7 +69,8 @@ export const getNotices: RequestHandler = async (req, res, next) => {
           createdAt: notice.createdAt,
           isPrior: notice.isPrior,
         };
-      });
+      })
+      .slice(0, 2);
     res.status(200).json(noticeList);
   } catch (error) {
     next(error);

--- a/src/controller/schedule/controller.ts
+++ b/src/controller/schedule/controller.ts
@@ -64,10 +64,10 @@ export const TeamScheAdd: RequestHandler = async (req, res, next) => {
         const memberList = TeamService.getMemberByTeam(teamId);
         (await memberList).forEach(
           async (memberInfo) =>
-            await AlarmService.createScheAlarm(
+            await AlarmService.createAlarm(
+              `${team.teamname}에 ${publicScheAddReq.name} 일정이 추가되었습니다.`,
               memberInfo.id,
-              team,
-              publicScheAddReq.name,
+              teamId,
             ),
         );
         return res.status(200).json();

--- a/src/controller/schedule/controller.ts
+++ b/src/controller/schedule/controller.ts
@@ -15,6 +15,7 @@ import {
 } from '../../util/customErrors';
 import AlarmService from '../../service/alarm.service';
 import TeamService from '../../service/team.service';
+import NoticeService from '../../service/notice.service';
 
 declare module 'express-session' {
   interface SessionData {
@@ -145,6 +146,18 @@ export const ScheEdit: RequestHandler = async (req, res, next) => {
       schedule.explanation = scheEditReq.explanation;
       const result = await ScheService.ScheSave(schedule);
       if (result !== null) {
+        const teamSchedule = await NoticeService.findTeamScheByScheId(
+          Number(scheduleId),
+        );
+        if (teamSchedule) {
+          const team = await TeamService.getTeamById(teamSchedule.team.id);
+          if (team)
+            await AlarmService.createAlarm(
+              `${team.teamname}의 ${schedule.schedulename} 일정이 수정되었습니다.`,
+              Number(req.session.passport?.user),
+              team.id,
+            );
+        }
         return res.status(200).json();
       } else {
         throw new InternalServerError('일정 정보 반영 실패');
@@ -165,6 +178,18 @@ export const ScheDelete: RequestHandler = async (req, res, next) => {
       schedule.deletedAt = new Date();
       const result = await ScheService.ScheSave(schedule);
       if (result !== null) {
+        const teamSchedule = await NoticeService.findTeamScheByScheId(
+          Number(scheduleId),
+        );
+        if (teamSchedule) {
+          const team = await TeamService.getTeamById(teamSchedule.team.id);
+          if (team)
+            await AlarmService.createAlarm(
+              `${team.teamname}의 ${schedule.schedulename} 일정이 삭제되었습니다.`,
+              Number(req.session.passport?.user),
+              team.id,
+            );
+        }
         return res.status(200).json();
       } else {
         throw new InternalServerError('일정 정보 반영 실패');

--- a/src/controller/team/controller.ts
+++ b/src/controller/team/controller.ts
@@ -147,8 +147,8 @@ export const showTeam: RequestHandler = async (req, res, next) => {
             createdAt: notice.createdAt,
             isPrior: notice.isPrior,
           };
-        })
-        .slice(0, 2);
+        });
+
       // team id로 member 찾기
       const members = (await TeamService.getMemberByTeam(
         teamId,

--- a/src/controller/team/controller.ts
+++ b/src/controller/team/controller.ts
@@ -133,14 +133,25 @@ export const showTeam: RequestHandler = async (req, res, next) => {
       // team id로 notice 찾기
       const noticeList = await NoticeService.getNoticeByTeamId(teamId);
       if (!noticeList) throw new BadRequestError('해당하는 모임이 없습니다.');
-      const notices = noticeList.map((notice) => {
-        return <NoticesDTO>{
-          id: notice.id,
-          content: notice.content,
-          createdAt: notice.createdAt,
-          isPrior: notice.isPrior,
-        };
-      });
+      const notices = noticeList
+        .filter(
+          (notice) =>
+            notice.startDate &&
+            notice.endDate &&
+            new Date() > notice.startDate &&
+            new Date() < notice.endDate,
+        )
+        .sort((a, b) => Number(b.updatedAt) - Number(a.updatedAt))
+        .sort((a, b) => Number(b.isPrior) - Number(a.isPrior))
+        .map((notice) => {
+          return <NoticesDTO>{
+            id: notice.id,
+            content: notice.content,
+            createdAt: notice.createdAt,
+            isPrior: notice.isPrior,
+          };
+        })
+        .slice(0, 2);
       // team id로 member 찾기
       const members = (await TeamService.getMemberByTeam(
         teamId,

--- a/src/controller/team/controller.ts
+++ b/src/controller/team/controller.ts
@@ -10,16 +10,13 @@ import {
   TeamReadResDTO,
   TeamUpdateReqDTO,
 } from '../../type/team.dto';
-import Team from '../../entity/team.entity';
 import {
   BadRequestError,
   ForbiddenError,
   UnauthorizedError,
 } from '../../util/customErrors';
-import MemberTeamService from '../../service/memberTeam.service';
 import ScheService from '../../service/schedule.service';
 import NoticeService from '../../service/notice.service';
-import { NoticeResDTO } from '../../type/notice.dto';
 
 declare module 'express-session' {
   interface SessionData {

--- a/src/controller/team/router.ts
+++ b/src/controller/team/router.ts
@@ -18,7 +18,6 @@ import {
 
 const teamRouter = Router();
 
-
 teamRouter.patch('/favorite/:teamId', toggleFavoriteTeam);
 teamRouter.patch('/hide/:teamId', toggleHideTeam);
 
@@ -32,7 +31,7 @@ teamRouter.post('/create', createTeam); // body를 사용하여 team 정보 저�
 teamRouter.get('/', myTeam); // userId에 맞는 team 정보 가져오기
 teamRouter.get('/search', searchTeam); // query를 사용하여 team 정보 가져오기
 teamRouter.patch('/:teamId', updateTeam); // param와 body를 사용하여 해당하는 team 정보 수정
-//teamRouter.get('/team/:teamId', showTeam); // param을 사용하여 해당하는 team 정보 가져오기
+teamRouter.get('/:teamId', showTeam); // param을 사용하여 해당하는 team 정보 가져오기
 teamRouter.delete('/:teamId', deleteTeam); // param을 사용하여 해당하는 team 정보 삭제
 
 export default teamRouter;

--- a/src/entity/notice.entity.ts
+++ b/src/entity/notice.entity.ts
@@ -47,7 +47,7 @@ export default class Notice {
   createdAt!: Date;
 
   @UpdateDateColumn({ type: 'timestamp', nullable: true })
-  updatedAt?: Date;
+  updatedAt!: Date;
 
   @DeleteDateColumn({ type: 'timestamp', nullable: true })
   deletedAt?: Date;

--- a/src/entity/team.entity.ts
+++ b/src/entity/team.entity.ts
@@ -25,10 +25,11 @@ export default class Team {
   teamname!: string;
 
   @Column({
-    type: 'int',
+    type: 'varchar',
+    length: 16,
     nullable: false,
   })
-  color!: number;
+  color!: string;
 
   @Column({
     type: 'varchar',

--- a/src/service/alarm.service.ts
+++ b/src/service/alarm.service.ts
@@ -56,33 +56,15 @@ export default class AlarmService {
     }
   }
 
-  static async createInviteAlarm(
+  static async createAlarm(
+    content: string,
     memberId: number,
-    team: Team,
+    teamId: number,
   ): Promise<InsertResult> {
     try {
-      const content = `${team.teamname} 그룹에 초대되었습니다.`;
       return await AlarmRepository.insert({
         member: { id: memberId },
-        team: { id: team.id },
-        schedule: { id: null } as any,
-        content: content,
-        isRead: false,
-      });
-    } catch (error) {
-      throw new InternalServerError('알람 생성에 실패했습니다.');
-    }
-  }
-  static async createScheAlarm(
-    memberId: number,
-    team: Team,
-    scheName: string,
-  ): Promise<InsertResult> {
-    try {
-      const content = `${team.teamname}에 ${scheName} 일정이 추가되었습니다.`;
-      return await AlarmRepository.insert({
-        member: { id: memberId },
-        team: { id: team.id },
+        team: { id: teamId },
         schedule: { id: null } as any,
         content: content,
         isRead: false,

--- a/src/service/alarm.service.ts
+++ b/src/service/alarm.service.ts
@@ -1,4 +1,5 @@
 import Alarm from '../entity/alarm.entity';
+import Team from '../entity/team.entity';
 import AlarmRepository from '../repository/alarm.repository';
 import { InternalServerError } from '../util/customErrors';
 import { DeleteResult, InsertResult, UpdateResult } from 'typeorm';
@@ -6,7 +7,6 @@ import { DeleteResult, InsertResult, UpdateResult } from 'typeorm';
 export default class AlarmService {
   static async getAlarm(memberId: number): Promise<Alarm[]> {
     try {
-      console.log(memberId);
       return await AlarmRepository.createQueryBuilder('alarm')
         .innerJoin('alarm.team', 'team.id')
         .leftJoin('alarm.schedule', 'schedule.id')
@@ -58,13 +58,31 @@ export default class AlarmService {
 
   static async createInviteAlarm(
     memberId: number,
-    teamId: number,
+    team: Team,
   ): Promise<InsertResult> {
     try {
-      const content = `${teamId} 그룹에 초대되었습니다.`;
+      const content = `${team.teamname} 그룹에 초대되었습니다.`;
       return await AlarmRepository.insert({
         member: { id: memberId },
-        team: { id: teamId },
+        team: { id: team.id },
+        schedule: { id: null } as any,
+        content: content,
+        isRead: false,
+      });
+    } catch (error) {
+      throw new InternalServerError('알람 생성에 실패했습니다.');
+    }
+  }
+  static async createScheAlarm(
+    memberId: number,
+    team: Team,
+    scheName: string,
+  ): Promise<InsertResult> {
+    try {
+      const content = `${team.teamname}에 ${scheName} 일정이 추가되었습니다.`;
+      return await AlarmRepository.insert({
+        member: { id: memberId },
+        team: { id: team.id },
         schedule: { id: null } as any,
         content: content,
         isRead: false,

--- a/src/service/memberTeam.service.ts
+++ b/src/service/memberTeam.service.ts
@@ -1,5 +1,4 @@
 import { DeleteResult, InsertResult, UpdateResult } from 'typeorm';
-import MemberTeam from '../entity/team.entity';
 import MemberTeamRepository from '../repository/memberTeam.repository';
 import TeamRepository from '../repository/team.repository';
 import { InternalServerError } from '../util/customErrors';

--- a/src/service/schedule.service.ts
+++ b/src/service/schedule.service.ts
@@ -10,7 +10,6 @@ import Team from '../entity/team.entity';
 import Schedule from '../entity/schedule.entity';
 import MemberSchedule from '../entity/memberSchedule.entity';
 import TeamSchedule from '../entity/teamSchedule.entity';
-
 import ScheduleRepository from '../repository/schedule.repository';
 import MemberScheduleRepository from '../repository/memberSchedule.repository';
 import TeamScheduleRepository from '../repository/teamSchedule.repository';

--- a/src/type/schedule.dto.ts
+++ b/src/type/schedule.dto.ts
@@ -8,7 +8,7 @@ export interface ScheduleDTO {
 export interface TeamScheResDTO {
   teamId: number;
   teamname: string;
-  color: number;
+  color: string;
   schedules: ScheduleDTO[];
 }
 

--- a/src/type/team.dto.ts
+++ b/src/type/team.dto.ts
@@ -1,9 +1,6 @@
-import { NoticeResDTO } from './notice.dto';
-import { ScheduleDTO } from './schedule.dto';
-
 export interface TeamCreateReqDTO {
   teamname: string;
-  color: number;
+  color: string;
   explanation: string;
   isPublic: boolean;
 }
@@ -20,13 +17,13 @@ export interface MyTeamResDTO {
 export interface TeamListResDTO {
   id: number;
   teamname: string;
-  color: number;
+  color: string;
   explanation: string;
 }
 
 export interface TeamUpdateReqDTO {
   teamname: string;
-  color: number;
+  color: string;
   explanation: string;
 }
 
@@ -53,7 +50,7 @@ export interface NoticesDTO {
 
 export interface TeamReadResDTO {
   teamname: string;
-  color: number;
+  color: string;
   explanation: string;
   isPublic: boolean;
   members: TeamMemberDTO[];


### PR DESCRIPTION
## 수정한 점
- color type number -> string
- createAlarm service
- showTeam controller에서 공지사항 두 개 제공 -> 전체 제공

### 1. color type
team.entity부터 시작해서 color가 나오는 dto에서 타입이 number로 되어 있는 것을 string으로 바꿨습니다. 
### 2. createAlarm service
원래 createInviteAlarm이 있었는데 createAdminAlarm, createScheAlarm을 만들고 보니 content만 달라서 createAlarm으로 통합했습니다. 초대되었을 때, 어드민이 되었을 때, 모임에서 스케줄을 생성했을 때 알람을 받습니다.
### 3. showTeam notices
기한 내의 공지사항을 중요인 것, 최근 업데이트된 것 순으로 정렬해서 2개만 보내줬는데 다 보내주는 것으로 수정했습니다. 
## 추가할 점
알람 생성이 언제 또 되면 좋을까요?
모임 일정 수정, 삭제 시 알람 추가 (1.18 9:59)